### PR TITLE
test: fix test-trace-gc-flag

### DIFF
--- a/test/v8-updates/test-trace-gc-flag.js
+++ b/test/v8-updates/test-trace-gc-flag.js
@@ -24,7 +24,7 @@ const fixtures = require('../common/fixtures');
     scavengeRegex,
     scavengeRegex,
     scavengeRegex,
-    /\bMark-sweep\b/,
+    /\bMark-Compact\b/,
   ];
   lines.forEach((line, index) => {
     assert.match(line, expectedOutput[index]);


### PR DESCRIPTION
This pull request fix `test/v8-updates/test-trace-gc-flag.js`

Ref: https://github.com/nodejs/node/pull/45230#issuecomment-1296912010