### PR TITLE
fix some clang-cl warnings regarding unused parameters

### DIFF
--- a/deps/base64/base64.gyp
+++ b/deps/base64/base64.gyp
@@ -78,6 +78,7 @@
       'include_dirs': [ 'base64/include', 'base64/lib' ],
       'sources': [ 'base64/lib/arch/ssse3/codec.c' ],
       'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_SSSE3=1' ],
+      'cflags_cpp': [],
       'conditions': [
         [ 'OS!="win"', {
           'cflags': [ '-mssse3' ],
@@ -102,6 +103,7 @@
       'include_dirs': [ 'base64/include', 'base64/lib' ],
       'sources': [ 'base64/lib/arch/sse41/codec.c' ],
       'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_SSE41=1' ],
+      'cflags_cpp': [],
       'conditions': [
         [ 'OS!="win"', {
           'cflags': [ '-msse4.1' ],
@@ -126,6 +128,7 @@
       'include_dirs': [ 'base64/include', 'base64/lib' ],
       'sources': [ 'base64/lib/arch/sse42/codec.c' ],
       'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_SSE42=1' ],
+      'cflags_cpp': [],
       'conditions': [
         [ 'OS!="win"', {
           'cflags': [ '-msse4.2' ],
@@ -150,9 +153,10 @@
       'include_dirs': [ 'base64/include', 'base64/lib' ],
       'sources': [ 'base64/lib/arch/avx/codec.c' ],
       'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_AVX=1' ],
+      'cflags_cpp': [],
+      'cflags': [ '-mavx' ],
       'conditions': [
         [ 'OS!="win"', {
-          'cflags': [ '-mavx' ],
           'xcode_settings': {
             'OTHER_CFLAGS': [ '-mavx' ]
           },
@@ -174,9 +178,10 @@
       'include_dirs': [ 'base64/include', 'base64/lib' ],
       'sources': [ 'base64/lib/arch/avx2/codec.c' ],
       'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_AVX2=1' ],
+      'cflags_cpp': [],
+      'cflags': [ '-mavx2' ],
       'conditions': [
         [ 'OS!="win"', {
-          'cflags': [ '-mavx2' ],
           'xcode_settings': {
             'OTHER_CFLAGS': [ '-mavx2' ]
           },
@@ -198,9 +203,10 @@
       'include_dirs': [ 'base64/include', 'base64/lib' ],
       'sources': [ 'base64/lib/arch/avx512/codec.c' ],
       'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_AVX512=1' ],
+      'cflags_cpp': [],
+      'cflags': [ '-mavx512f', '-mavx512vl', '-mavx512vbmi' ],
       'conditions': [
         [ 'OS!="win"', {
-          'cflags': [ '-mavx512vl', '-mavx512vbmi' ],
           'xcode_settings': {
             'OTHER_CFLAGS': [ '-mavx512vl', '-mavx512vbmi' ]
           },
@@ -222,6 +228,7 @@
       'include_dirs': [ 'base64/include', 'base64/lib' ],
       'sources': [ 'base64/lib/arch/neon32/codec.c' ],
       'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_NEON32=1' ],
+      'cflags_cpp': [],
       'conditions': [
         [ 'OS!="win"', {
           'cflags': [ '-mfpu=neon' ],

--- a/deps/base64/unofficial.gni
+++ b/deps/base64/unofficial.gni
@@ -136,7 +136,8 @@ template("base64_gn_build") {
           "-mavx512vbmi",
         ]
       } else if (is_win) {
-        cflags_c = [ "/arch:AVX512" ]
+        cflags_c = [ "/arch:AVX512" ],
+        cflags_cpp = []
       }
     }
   }

--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -163,12 +163,14 @@
             '-Wextra',
             '-Wno-unused-parameter'
           ],
+          'cflags_cpp': [],
           'defines': [ 'HAVE_CONFIG_H' ],
         }],
         [ 'OS not in "win android"', {
           'cflags': [
             '--std=gnu89'
           ],
+          'cflags_cpp': [],
         }],
         [ 'OS=="linux"', {
           'include_dirs': [ 'config/linux' ],

--- a/deps/histogram/histogram.gyp
+++ b/deps/histogram/histogram.gyp
@@ -10,6 +10,7 @@
       'target_name': 'histogram',
       'type': 'static_library',
       'cflags': ['-fvisibility=hidden'],
+      'cflags_cpp': [],
       'xcode_settings': {
         'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
       },

--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -92,6 +92,7 @@
       'includes': ['./openssl_common.gypi'],
       'include_dirs+': ['openssl/apps/include'],
       'cflags': [ '-fPIC' ],
+      'cflags_cpp': [],
       #'ldflags': [ '-o', 'fips.so' ],
       #'ldflags': [ '-Wl,--version-script=providers/fips.ld',],
       'conditions': [

--- a/deps/openssl/openssl_common.gypi
+++ b/deps/openssl/openssl_common.gypi
@@ -34,6 +34,7 @@
       'cflags': [
         '-W3', '-wd4090', '-Gs0', '-GF', '-Gy', '-nologo','/O2',
       ],
+      'cflags_cpp': [],
       'msvs_disabled_warnings': [4090],
       'link_settings': {
         'libraries': [

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -18,6 +18,8 @@
           'conditions': [
             ['target_arch in "ia32 x64" and OS!="ios"', {
               'defines': [ 'ADLER32_SIMD_SSSE3' ],
+              'cflags': [ '-mssse3' ],
+              'cflags_cpp': [],
               'conditions': [
                 ['OS=="win"', {
                   'defines': [ 'X86_WINDOWS' ],
@@ -25,7 +27,6 @@
                   'defines': [ 'X86_NOT_WINDOWS' ],
                 }],
                 ['OS!="win" or llvm_version!="0.0"', {
-                  'cflags': [ '-mssse3' ],
                   'xcode_settings': {
                     'OTHER_CFLAGS': [ '-mssse3' ],
                   },
@@ -62,6 +63,7 @@
         {
           'target_name': 'zlib_arm_crc32',
           'type': 'static_library',
+          'cflags_cpp': [],
           'conditions': [
             ['OS!="ios"', {
               'conditions': [
@@ -174,6 +176,7 @@
         {
           'target_name': 'zlib',
           'type': 'static_library',
+          'cflags_cpp': [],
           'sources': [
             '<!@pymod_do_main(GN-scraper "<(ZLIB_ROOT)/BUILD.gn" "\\"zlib\\".*?sources = ")',
           ],
@@ -250,6 +253,7 @@
         {
           'target_name': 'zlib',
           'type': 'static_library',
+          'cflags_cpp': [],
           'direct_dependent_settings': {
             'defines': [
               'USE_SYSTEM_ZLIB',


### PR DESCRIPTION
They occur because we try to compile C code as C++17. The `-std=c++17` flag should not be used when compiling C code. A quickfix is to set `cflags_cc=[]` in C dependencies. It clears the C++ flags.

Interestingly, it illustrates that the following configuration...

```
            ['target_arch in "ia32 x64" and OS!="ios"', {
              'defines': [ 'ADLER32_SIMD_SSSE3' ],
              'cflags': [ '-mssse3' ],
              'cflags_cc': [],
              'conditions': [
```

is not triggered. So you get both a build error because you are missing SSSE3, but also a visible warning.

I am sure that it is quite trivial.