### PR TITLE
fix build on clangcl, except for v8 assembly

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -284,9 +284,13 @@
     ],
     'msvs_settings': {
       'VCCLCompilerTool': {
+        # Node has C and C++ dependencies: we want to specify the standards
+        # independently. Recent versions of Visual Studio support C11 and C17
+        # https://learn.microsoft.com/en-us/cpp/overview/install-c17-support?view=msvc-170
+        'LanguageStandard': 'stdcpp17',       # can switch to stdcpp20 or better
+        'LanguageStandard_C': 'stdc11',       # can switch to stdc17 or better
         'AdditionalOptions': [
           '/Zc:__cplusplus',
-          '-std:c++17'
         ],
         'BufferSecurityCheck': 'true',
         'DebugInformationFormat': 1,          # /Z7 embed info in .obj files

--- a/deps/base64/base64.gyp
+++ b/deps/base64/base64.gyp
@@ -42,7 +42,8 @@
         }],
 
         # Runtime detection will happen for x86 CPUs
-        [ 'target_arch in "ia32 x64 x32"', {
+        # Except for ClangCL.
+        [ 'target_arch in "ia32 x64 x32" and OS!="win"', {
           'defines': [
             'HAVE_SSSE3=1',
             'HAVE_SSE41=1',
@@ -159,9 +160,7 @@
         }, {
           'msvs_settings': {
             'VCCLCompilerTool': {
-              'AdditionalOptions': [
-                '/arch:AVX'
-              ],
+              'EnableEnhancedInstructionSet': '3' # gyp uses a digit instead of a string such as 'AVX'
             },
           },
         }],
@@ -183,9 +182,7 @@
         }, {
           'msvs_settings': {
             'VCCLCompilerTool': {
-              'AdditionalOptions': [
-                '/arch:AVX2'
-              ],
+              'EnableEnhancedInstructionSet': '5' # gyp uses a digit instead of a string such as 'AVX2'
             },
           },
         }],
@@ -207,9 +204,7 @@
         }, {
           'msvs_settings': {
             'VCCLCompilerTool': {
-              'AdditionalOptions': [
-                '/arch:AVX512'
-              ],
+              'EnableEnhancedInstructionSet': '6' # gyp uses a digit instead of a string such as 'AVX512'
             },
           },
         }],

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -17,12 +17,11 @@
           'type': 'static_library',
           'conditions': [
             ['target_arch in "ia32 x64" and OS!="ios"', {
-              'defines': [ 'ADLER32_SIMD_SSSE3' ],
               'conditions': [
                 ['OS=="win"', {
                   'defines': [ 'X86_WINDOWS' ],
                 },{
-                  'defines': [ 'X86_NOT_WINDOWS' ],
+                  'defines': [ 'X86_NOT_WINDOWS', 'ADLER32_SIMD_SSSE3' ],
                 }],
                 ['OS!="win" or llvm_version!="0.0"', {
                   'cflags': [ '-mssse3' ],
@@ -40,12 +39,11 @@
           'direct_dependent_settings': {
             'conditions': [
               ['target_arch in "ia32 x64" and OS!="ios"', {
-                'defines': [ 'ADLER32_SIMD_SSSE3' ],
                 'conditions': [
                   ['OS=="win"', {
                     'defines': [ 'X86_WINDOWS' ],
                   },{
-                    'defines': [ 'X86_NOT_WINDOWS' ],
+                    'defines': [ 'X86_NOT_WINDOWS', 'ADLER32_SIMD_SSSE3' ],
                   }],
                 ],
               }],

--- a/tools/gyp/pylib/gyp/MSVSSettings.py
+++ b/tools/gyp/pylib/gyp/MSVSSettings.py
@@ -579,6 +579,8 @@ _msbuild_validators["ManifestResourceCompile"] = {}
 # Options that have the same name in MSVS and MSBuild
 _Same(_compile, "AdditionalIncludeDirectories", _folder_list)  # /I
 _Same(_compile, "AdditionalOptions", _string_list)
+_Same(_compile, "LanguageStandard", _string)
+_Same(_compile, "LanguageStandard_C", _string)
 _Same(_compile, "AdditionalUsingDirectories", _folder_list)  # /AI
 _Same(_compile, "AssemblerListingLocation", _file_name)  # /Fa
 _Same(_compile, "BrowseInformationFile", _file_name)
@@ -675,6 +677,7 @@ _Same(
             "NoExtensions",  # /arch:IA32 (vs2012+)
             # This one only exists in the new msbuild format.
             "AdvancedVectorExtensions2",  # /arch:AVX2 (vs2013r2+)
+            "AdvancedVectorExtensions512",  #  (vs2019+)
         ]
     ),
 )

--- a/tools/gyp/pylib/gyp/msvs_emulation.py
+++ b/tools/gyp/pylib/gyp/msvs_emulation.py
@@ -531,7 +531,7 @@ class MsvsSettings:
         cl("AdditionalOptions", prefix="")
         cl(
             "EnableEnhancedInstructionSet",
-            map={"1": "SSE", "2": "SSE2", "3": "AVX", "4": "IA32", "5": "AVX2"},
+            map={"1": "SSE", "2": "SSE2", "3": "AVX", "4": "IA32", "5": "AVX2", "6": "AVX512"},
             prefix="/arch:",
         )
         cflags.extend(


### PR DESCRIPTION
1. To avoid many warnings, this PR declares the C and C++ standards separately.
2. This PR extends gyp so that we can build with AVX-512. Nevertheless, getting runtime dispatching with ClangCl through Visual Studio is challenging, so we disable it. It only affects base64 and one component of zip, so the effect on runtime performance should be negligible. Note that other dependencies such as simdutf do not need to this build support for runtime dispatching (so you still get AVX2, AVX-512 support in these dependencies).

This PR does not fix the issue with v8 assembly that does not build.