### PR TITLE
fix: call asm_to_inline_asm, correct lib paths and remove masm

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -581,8 +581,8 @@
           'msvs_settings': {
             'VCLinkerTool': {
               'AdditionalOptions': [
-                '/WHOLEARCHIVE:<(node_lib_target_name)<(STATIC_LIB_SUFFIX)',
-                '/WHOLEARCHIVE:<(STATIC_LIB_PREFIX)v8_base_without_compiler<(STATIC_LIB_SUFFIX)',
+                '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/<(node_lib_target_name)<(STATIC_LIB_SUFFIX)',
+                '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/<(STATIC_LIB_PREFIX)v8_base_without_compiler<(STATIC_LIB_SUFFIX)',
               ],
             },
           },

--- a/node.gypi
+++ b/node.gypi
@@ -155,7 +155,7 @@
           'msvs_settings': {
             'VCLinkerTool': {
               'AdditionalOptions': [
-                '/WHOLEARCHIVE:zlib<(STATIC_LIB_SUFFIX)',
+                '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/zlib<(STATIC_LIB_SUFFIX)',
               ],
             },
           },
@@ -194,7 +194,7 @@
           'msvs_settings': {
             'VCLinkerTool': {
               'AdditionalOptions': [
-                '/WHOLEARCHIVE:libuv<(STATIC_LIB_SUFFIX)',
+                '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/libuv<(STATIC_LIB_SUFFIX)',
               ],
             },
           },
@@ -373,7 +373,7 @@
               'msvs_settings': {
                 'VCLinkerTool': {
                   'AdditionalOptions': [
-                    '/WHOLEARCHIVE:<(openssl_product)',
+                    '/WHOLEARCHIVE:<(PRODUCT_DIR)/lib/<(openssl_product)',
                   ],
                 },
               },

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1805,25 +1805,6 @@
               }],
             ]
           }],
-          ['OS=="win"', {
-            'conditions': [
-              ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
-                'sources': [
-                  '<(V8_ROOT)/src/heap/base/asm/x64/push_registers_masm.asm',
-                ],
-              }],
-              ['_toolset == "host" and host_arch == "ia32" or _toolset == "target" and target_arch=="ia32"', {
-                'sources': [
-                  '<(V8_ROOT)/src/heap/base/asm/ia32/push_registers_masm.asm',
-                ],
-              }],
-              ['_toolset == "host" and host_arch == "arm64" or _toolset == "target" and target_arch=="arm64"', {
-                'sources': [
-                  '<(V8_ROOT)/src/heap/base/asm/arm64/push_registers_masm.S',
-                ],
-              }],
-            ],
-          }],
         ],
       },
     },  # v8_heap_base

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -410,7 +410,6 @@
             '<(INTERMEDIATE_DIR)/snapshot.cc',
             '<(INTERMEDIATE_DIR)/embedded.S',
           ],
-          'process_outputs_as_sources': 1,
           'conditions': [
             ['v8_random_seed', {
               'variables': {
@@ -448,6 +447,24 @@
           'action': [
             '>@(_inputs)',
             '>@(mksnapshot_flags)',
+          ],
+        },
+        {
+          'action_name': 'asm_to_inline_asm',
+          'message': 'generating: >@(_outputs)',
+          'inputs': [
+            '<(INTERMEDIATE_DIR)/embedded.S',
+          ],
+          'outputs': [
+            '<(INTERMEDIATE_DIR)/snapshot.cc',
+            '<(INTERMEDIATE_DIR)/embedded.cc',
+          ],
+          'process_outputs_as_sources': 1,
+          'action': [
+            '<(python)',
+            '<(V8_ROOT)/tools/snapshot/asm_to_inline_asm.py',
+            '<@(_inputs)',
+            '<(INTERMEDIATE_DIR)/embedded.cc',
           ],
         },
       ],


### PR DESCRIPTION
With this PR, I am able to get a clean build with ClangCL. The PR does three things:

1. Instead of trying to compile the snapshot asm directly, it embeds it in cc file using `tools/snapshot/asm_to_inline_asm.py`. It is how v8 does it.
2. Visual Studio could not find some libraries with ClangCL when passing `/WHOLEARCHIVE:nameoflib` so we correct the problem by providing the full path.
3. We remove the masm builds as they are no longer necessary. 