### PR TITLE
V8 v12.2 Windows patch

### DIFF
--- a/deps/v8/src/builtins/builtins-collections-gen.cc
+++ b/deps/v8/src/builtins/builtins-collections-gen.cc
@@ -2782,10 +2782,9 @@ TNode<Word32T> WeakCollectionsBuiltinsAssembler::ShouldShrink(
 
 TNode<IntPtrT> WeakCollectionsBuiltinsAssembler::ValueIndexFromKeyIndex(
     TNode<IntPtrT> key_index) {
-  return IntPtrAdd(
-      key_index,
-      IntPtrConstant(EphemeronHashTable::TodoShape::kEntryValueIndex -
-                     EphemeronHashTable::kEntryKeyIndex));
+  return IntPtrAdd(key_index,
+                   IntPtrConstant(EphemeronHashTable::ShapeT::kEntryValueIndex -
+                                  EphemeronHashTable::kEntryKeyIndex));
 }
 
 TF_BUILTIN(WeakMapConstructor, WeakCollectionsBuiltinsAssembler) {

--- a/deps/v8/src/codegen/code-stub-assembler.cc
+++ b/deps/v8/src/codegen/code-stub-assembler.cc
@@ -9455,7 +9455,7 @@ void CodeStubAssembler::NameDictionaryLookup(
         CAST(UnsafeLoadFixedArrayElement(dictionary, index));
     GotoIf(TaggedEqual(current, undefined), if_not_found);
     if (mode == kFindExisting) {
-      if (Dictionary::TodoShape::kMatchNeedsHoleCheck) {
+      if (Dictionary::ShapeT::kMatchNeedsHoleCheck) {
         GotoIf(TaggedEqual(current, TheHoleConstant()), &next_probe);
       }
       current = LoadName<Dictionary>(current);

--- a/deps/v8/src/compiler/turboshaft/assembler.h
+++ b/deps/v8/src/compiler/turboshaft/assembler.h
@@ -3934,8 +3934,9 @@ class TSAssembler
     : public Assembler<reducer_list<TurboshaftAssemblerOpInterface, Reducers...,
                                     TSReducerBase>> {
  public:
-  using Assembler<reducer_list<TurboshaftAssemblerOpInterface, Reducers...,
-                               TSReducerBase>>::Assembler;
+  explicit TSAssembler(Graph& input_graph, Graph& output_graph,
+                       Zone* phase_zone)
+      : Assembler(input_graph, output_graph, phase_zone) {}
 };
 
 #include "src/compiler/turboshaft/undef-assembler-macros.inc"

--- a/deps/v8/src/compiler/turboshaft/code-elimination-and-simplification-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/code-elimination-and-simplification-phase.cc
@@ -32,7 +32,8 @@ void CodeEliminationAndSimplificationPhase::Run(Zone* temp_zone) {
                // (which, for simplificy, doesn't use the Assembler helper
                // methods, but only calls Next::ReduceLoad/Store).
                DuplicationOptimizationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer,
+               VariableReducerHotfix>::Run<false>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/csa-optimize-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/csa-optimize-phase.cc
@@ -25,23 +25,23 @@ namespace v8::internal::compiler::turboshaft {
 void CsaLoadEliminationPhase::Run(Zone* temp_zone) {
   CopyingPhase<VariableReducer, MachineOptimizationReducer,
                RequiredOptimizationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer>::Run<true>(temp_zone);
 
   CopyingPhase<VariableReducer, LateLoadEliminationReducer,
                MachineOptimizationReducer, RequiredOptimizationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 void CsaLateEscapeAnalysisPhase::Run(Zone* temp_zone) {
   CopyingPhase<VariableReducer, LateEscapeAnalysisReducer,
                MachineOptimizationReducer, RequiredOptimizationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 void CsaBranchEliminationPhase::Run(Zone* temp_zone) {
   CopyingPhase<VariableReducer, MachineOptimizationReducer,
                BranchEliminationReducer, RequiredOptimizationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 void CsaOptimizePhase::Run(Zone* temp_zone) {
@@ -51,7 +51,7 @@ void CsaOptimizePhase::Run(Zone* temp_zone) {
   CopyingPhase<VariableReducer, PretenuringPropagationReducer,
                MachineOptimizationReducer, MemoryOptimizationReducer,
                RequiredOptimizationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/debug-feature-lowering-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/debug-feature-lowering-phase.cc
@@ -11,7 +11,7 @@ namespace v8::internal::compiler::turboshaft {
 
 void DebugFeatureLoweringPhase::Run(Zone* temp_zone) {
 #ifdef V8_ENABLE_DEBUG_CODE
-  turboshaft::CopyingPhase<turboshaft::DebugFeatureLoweringReducer>::Run(
+  turboshaft::CopyingPhase<turboshaft::DebugFeatureLoweringReducer>::Run<false>(
       temp_zone);
 #endif
 }

--- a/deps/v8/src/compiler/turboshaft/int64-lowering-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/int64-lowering-phase.cc
@@ -16,7 +16,7 @@ void Int64LoweringPhase::Run(Zone* temp_zone) {
 #if V8_TARGET_ARCH_32_BIT
   turboshaft::CopyingPhase<
       turboshaft::Int64LoweringReducer, turboshaft::VariableReducer,
-      turboshaft::RequiredOptimizationReducer>::Run(temp_zone);
+      turboshaft::RequiredOptimizationReducer>::Run<true>(temp_zone);
 #else
   UNREACHABLE();
 #endif

--- a/deps/v8/src/compiler/turboshaft/loop-peeling-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/loop-peeling-phase.cc
@@ -23,7 +23,7 @@ void LoopPeelingPhase::Run(Zone* temp_zone) {
                            turboshaft::VariableReducer,
                            turboshaft::MachineOptimizationReducer,
                            turboshaft::RequiredOptimizationReducer,
-                           turboshaft::ValueNumberingReducer>::Run(temp_zone);
+                           turboshaft::ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/loop-unrolling-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/loop-unrolling-phase.cc
@@ -22,7 +22,7 @@ void LoopUnrollingPhase::Run(Zone* temp_zone) {
                              turboshaft::VariableReducer,
                              turboshaft::MachineOptimizationReducer,
                              turboshaft::RequiredOptimizationReducer,
-                             turboshaft::ValueNumberingReducer>::Run(temp_zone);
+                             turboshaft::ValueNumberingReducer>::Run<true>(temp_zone);
     PipelineData::Get().clear_loop_unrolling_analyzer();
   }
 }

--- a/deps/v8/src/compiler/turboshaft/machine-lowering-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/machine-lowering-phase.cc
@@ -20,11 +20,11 @@ void MachineLoweringPhase::Run(Zone* temp_zone) {
     CopyingPhase<DataViewReducer, VariableReducer, MachineLoweringReducer,
                  FastApiCallReducer, RequiredOptimizationReducer,
                  SelectLoweringReducer,
-                 MachineOptimizationReducer>::Run(temp_zone);
+                 MachineOptimizationReducer>::Run<true>(temp_zone);
   } else {
     CopyingPhase<DataViewReducer, VariableReducer, MachineLoweringReducer,
                  FastApiCallReducer, RequiredOptimizationReducer,
-                 SelectLoweringReducer>::Run(temp_zone);
+                 SelectLoweringReducer>::Run<true>(temp_zone);
   }
 }
 

--- a/deps/v8/src/compiler/turboshaft/machine-optimization-reducer.h
+++ b/deps/v8/src/compiler/turboshaft/machine-optimization-reducer.h
@@ -1333,26 +1333,11 @@ class MachineOptimizationReducer : public Next {
         if (matcher.MatchConstantShiftRightArithmeticShiftOutZeros(
                 left, &x, rep_w, &k1) &&
             matcher.MatchIntegralWordConstant(right, rep_w, &k2) &&
-            CountLeadingSignBits(k2, rep_w) > k1) {
-          if (matcher.Get(left).saturated_use_count.IsZero()) {
-            return __ Comparison(
-                x, __ WordConstant(base::bits::Unsigned(k2) << k1, rep_w), kind,
-                rep_w);
-          } else if constexpr (reducer_list_contains<
-                                   ReducerList, ValueNumberingReducer>::value) {
-            // If the shift has uses, we only apply the transformation if the
-            // result would be GVNed away.
-            OpIndex rhs =
-                __ WordConstant(base::bits::Unsigned(k2) << k1, rep_w);
-            static_assert(ComparisonOp::input_count == 2);
-            static_assert(sizeof(ComparisonOp) == 8);
-            base::SmallVector<OperationStorageSlot, 32> storage;
-            ComparisonOp* cmp =
-                CreateOperation<ComparisonOp>(storage, x, rhs, kind, rep_w);
-            if (__ WillGVNOp(*cmp)) {
-              return __ Comparison(x, rhs, kind, rep_w);
-            }
-          }
+            CountLeadingSignBits(k2, rep_w) > k1 &&
+            matcher.Get(left).saturated_use_count.IsZero()) {
+          return __ Comparison(
+              x, __ WordConstant(base::bits::Unsigned(k2) << k1, rep_w), kind,
+              rep_w);
         }
         // k2 </<= (x >> k1)  =>  (k2 << k1) </<= x  if shifts reversible
         // Only perform the transformation if the shift is not used yet, to
@@ -1360,26 +1345,11 @@ class MachineOptimizationReducer : public Next {
         if (matcher.MatchConstantShiftRightArithmeticShiftOutZeros(
                 right, &x, rep_w, &k1) &&
             matcher.MatchIntegralWordConstant(left, rep_w, &k2) &&
-            CountLeadingSignBits(k2, rep_w) > k1) {
-          if (matcher.Get(right).saturated_use_count.IsZero()) {
-            return __ Comparison(
-                __ WordConstant(base::bits::Unsigned(k2) << k1, rep_w), x, kind,
-                rep_w);
-          } else if constexpr (reducer_list_contains<
-                                   ReducerList, ValueNumberingReducer>::value) {
-            // If the shift has uses, we only apply the transformation if the
-            // result would be GVNed away.
-            OpIndex lhs =
-                __ WordConstant(base::bits::Unsigned(k2) << k1, rep_w);
-            static_assert(ComparisonOp::input_count == 2);
-            static_assert(sizeof(ComparisonOp) == 8);
-            base::SmallVector<OperationStorageSlot, 32> storage;
-            ComparisonOp* cmp =
-                CreateOperation<ComparisonOp>(storage, lhs, x, kind, rep_w);
-            if (__ WillGVNOp(*cmp)) {
-              return __ Comparison(lhs, x, kind, rep_w);
-            }
-          }
+            CountLeadingSignBits(k2, rep_w) > k1 &&
+            matcher.Get(right).saturated_use_count.IsZero()) {
+          return __ Comparison(
+              __ WordConstant(base::bits::Unsigned(k2) << k1, rep_w), x, kind,
+              rep_w);
         }
       }
       // Map 64bit to 32bit comparisons.

--- a/deps/v8/src/compiler/turboshaft/optimize-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/optimize-phase.cc
@@ -30,7 +30,7 @@ void OptimizePhase::Run(Zone* temp_zone) {
                            turboshaft::MemoryOptimizationReducer,
                            turboshaft::MachineOptimizationReducer,
                            turboshaft::RequiredOptimizationReducer,
-                           turboshaft::ValueNumberingReducer>::Run(temp_zone);
+                           turboshaft::ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/simplified-lowering-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/simplified-lowering-phase.cc
@@ -10,7 +10,7 @@
 namespace v8::internal::compiler::turboshaft {
 
 void SimplifiedLoweringPhase::Run(Zone* temp_zone) {
-  CopyingPhase<SimplifiedLoweringReducer>::Run(temp_zone);
+  CopyingPhase<SimplifiedLoweringReducer>::Run<false>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/simplified-lowering-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/simplified-lowering-phase.cc
@@ -10,7 +10,7 @@
 namespace v8::internal::compiler::turboshaft {
 
 void SimplifiedLoweringPhase::Run(Zone* temp_zone) {
-  CopyingPhase<SimplifiedLoweringReducer>::Run<false>(temp_zone);
+  CopyingPhase<SimplifiedLoweringReducer, VariableReducerHotfix>::Run<false>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/simplified-lowering-reducer.h
+++ b/deps/v8/src/compiler/turboshaft/simplified-lowering-reducer.h
@@ -32,10 +32,10 @@ class SimplifiedLoweringReducer : public Next {
       OpIndex ig_index, const SpeculativeNumberBinopOp& op) {
     DCHECK_EQ(op.kind, SpeculativeNumberBinopOp::Kind::kSafeIntegerAdd);
 
-    OpIndex frame_state = Map(op.frame_state());
-    V<Word32> left = ProcessInput(Map(op.left()), Rep::Word32(),
+    OpIndex frame_state = MapImpl(op.frame_state());
+    V<Word32> left = ProcessInput(MapImpl(op.left()), Rep::Word32(),
                                   CheckKind::kSigned32, frame_state);
-    V<Word32> right = ProcessInput(Map(op.right()), Rep::Word32(),
+    V<Word32> right = ProcessInput(MapImpl(op.right()), Rep::Word32(),
                                    CheckKind::kSigned32, frame_state);
 
     V<Word32> result = __ OverflowCheckedBinop(
@@ -43,7 +43,7 @@ class SimplifiedLoweringReducer : public Next {
         WordRepresentation::Word32());
 
     V<Word32> overflow = __ Projection(result, 1, Rep::Word32());
-    __ DeoptimizeIf(overflow, Map(op.frame_state()),
+    __ DeoptimizeIf(overflow, MapImpl(op.frame_state()),
                     DeoptimizeReason::kOverflow, FeedbackSource{});
     return __ Projection(result, 0, Rep::Word32());
   }
@@ -52,10 +52,10 @@ class SimplifiedLoweringReducer : public Next {
     base::SmallVector<OpIndex, 8> return_values;
     for (OpIndex input : ret.return_values()) {
       return_values.push_back(
-          ProcessInput(Map(input), Rep::Tagged(), CheckKind::kNone, {}));
+          ProcessInput(MapImpl(input), Rep::Tagged(), CheckKind::kNone, {}));
     }
 
-    __ Return(Map(ret.pop_count()), base::VectorOf(return_values));
+    __ Return(MapImpl(ret.pop_count()), base::VectorOf(return_values));
     return OpIndex::Invalid();
   }
 
@@ -94,7 +94,7 @@ class SimplifiedLoweringReducer : public Next {
     }
   }
 
-  inline OpIndex Map(OpIndex ig_index) { return __ MapToNewGraph(ig_index); }
+  inline OpIndex MapImpl(OpIndex ig_index) { return __ MapToNewGraph(ig_index); }
 };
 
 #include "src/compiler/turboshaft/undef-assembler-macros.inc"

--- a/deps/v8/src/compiler/turboshaft/store-store-elimination-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/store-store-elimination-phase.cc
@@ -23,7 +23,7 @@ void StoreStoreEliminationPhase::Run(Zone* temp_zone) {
                            turboshaft::MachineOptimizationReducer,
                            turboshaft::RequiredOptimizationReducer,
                            turboshaft::BranchEliminationReducer,
-                           turboshaft::ValueNumberingReducer>::Run(temp_zone);
+                           turboshaft::ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/type-assertions-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/type-assertions-phase.cc
@@ -23,7 +23,8 @@ void TypeAssertionsPhase::Run(Zone* temp_zone) {
 
   turboshaft::CopyingPhase<turboshaft::AssertTypesReducer,
                            turboshaft::ValueNumberingReducer,
-                           turboshaft::TypeInferenceReducer>::Run(temp_zone);
+                           turboshaft::VariableReducerHotfix,
+                           turboshaft::TypeInferenceReducer>::Run<false>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/typed-optimizations-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/typed-optimizations-phase.cc
@@ -23,7 +23,8 @@ void TypedOptimizationsPhase::Run(Zone* temp_zone) {
       turboshaft::TypeInferenceReducerArgs::OutputGraphTyping::kNone};
 
   turboshaft::CopyingPhase<turboshaft::TypedOptimizationsReducer,
-                           turboshaft::TypeInferenceReducer>::Run(temp_zone);
+                           turboshaft::VariableReducerHotfix,
+                           turboshaft::TypeInferenceReducer>::Run<false>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/wasm-dead-code-elimination-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/wasm-dead-code-elimination-phase.cc
@@ -28,7 +28,8 @@ void WasmDeadCodeEliminationPhase::Run(Zone* temp_zone) {
                // (which, for simplificy, doesn't use the Assembler helper
                // methods, but only calls Next::ReduceLoad/Store).
                DuplicationOptimizationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer,
+               VariableReducerHotfix>::Run<false>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/wasm-gc-optimize-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/wasm-gc-optimize-phase.cc
@@ -15,7 +15,7 @@ namespace v8::internal::compiler::turboshaft {
 void WasmGCOptimizePhase::Run(Zone* temp_zone) {
   UnparkedScopeIfNeeded scope(PipelineData::Get().broker(),
                               v8_flags.turboshaft_trace_reduction);
-  CopyingPhase<WasmLoadEliminationReducer, WasmGCTypeReducer>::Run(temp_zone);
+  CopyingPhase<WasmLoadEliminationReducer, WasmGCTypeReducer, VariableReducerHotfix>::Run<false>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/wasm-lowering-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/wasm-lowering-phase.cc
@@ -21,7 +21,7 @@ void WasmLoweringPhase::Run(Zone* temp_zone) {
   // Also run the MachineOptimizationReducer as it can help the late load
   // elimination that follows this phase eliminate more loads.
   CopyingPhase<WasmLoweringReducer, VariableReducer, MachineOptimizationReducer,
-               RequiredOptimizationReducer>::Run(temp_zone);
+               RequiredOptimizationReducer>::Run<true>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/wasm-optimize-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/wasm-optimize-phase.cc
@@ -27,7 +27,7 @@ void WasmOptimizePhase::Run(Zone* temp_zone) {
                MemoryOptimizationReducer, VariableReducer,
                RequiredOptimizationReducer, BranchEliminationReducer,
                LateLoadEliminationReducer,
-               ValueNumberingReducer>::Run(temp_zone);
+               ValueNumberingReducer>::Run<true>(temp_zone);
 }
 
 }  // namespace v8::internal::compiler::turboshaft

--- a/deps/v8/src/compiler/turboshaft/wasm-revec-phase.cc
+++ b/deps/v8/src/compiler/turboshaft/wasm-revec-phase.cc
@@ -17,7 +17,7 @@ void WasmRevecPhase::Run(Zone* temp_zone) {
     PipelineData::Get().set_wasm_revec_analyzer(&analyzer);
     UnparkedScopeIfNeeded scope(PipelineData::Get().broker(),
                                 v8_flags.turboshaft_trace_reduction);
-    CopyingPhase<WasmRevecReducer>::Run(temp_zone);
+    CopyingPhase<WasmRevecReducer>::Run<false>(temp_zone);
     PipelineData::Get().clear_wasm_revec_analyzer();
   }
 }

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -3565,7 +3565,7 @@ void Heap::RightTrimArray(Tagged<Array> object, int new_capacity,
   }
 
   const int bytes_to_trim =
-      (old_capacity - new_capacity) * Array::Shape::kElementSize;
+      (old_capacity - new_capacity) * Array::HotfixShape::kElementSize;
 
   // Calculate location of new array end.
   const int old_size = Array::SizeFor(old_capacity);

--- a/deps/v8/src/objects/dictionary.h
+++ b/deps/v8/src/objects/dictionary.h
@@ -32,8 +32,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) Dictionary
   using DerivedHashTable = HashTable<Derived, Shape>;
 
  public:
-  using TodoShape = Shape;
-  using Key = typename TodoShape::Key;
+  using Key = typename Shape::Key;
   inline Tagged<Object> ValueAt(InternalIndex entry);
   inline Tagged<Object> ValueAt(PtrComprCageBase cage_base,
                                 InternalIndex entry);
@@ -126,7 +125,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) Dictionary
                              Key key, Handle<Object> value,
                              PropertyDetails details);
 
-  OBJECT_CONSTRUCTORS(Dictionary, HashTable<Derived, TodoShape>);
+  OBJECT_CONSTRUCTORS(Dictionary, HashTable<Derived, Shape>);
 };
 
 #define EXTERN_DECLARE_DICTIONARY(DERIVED, SHAPE)                  \

--- a/deps/v8/src/objects/fixed-array.h
+++ b/deps/v8/src/objects/fixed-array.h
@@ -24,13 +24,13 @@ namespace internal {
 #include "torque-generated/src/objects/fixed-array-tq.inc"
 
 // Derived: must have a Smi slot at kCapacityOffset.
-template <class Derived, class ShapeT, class Super = HeapObject>
+template <class Derived, class Shape, class Super = HeapObject>
 class TaggedArrayBase : public Super {
   static_assert(std::is_base_of<HeapObject, Super>::value);
   OBJECT_CONSTRUCTORS(TaggedArrayBase, Super);
 
-  using ElementT = typename ShapeT::ElementT;
-  static_assert(ShapeT::kElementSize == kTaggedSize);
+  using ElementT = typename Shape::ElementT;
+  static_assert(Shape::kElementSize == kTaggedSize);
   static_assert(is_subtype_v<ElementT, Object> ||
                 is_subtype_v<ElementT, MaybeObject>);
 
@@ -53,7 +53,7 @@ class TaggedArrayBase : public Super {
       std::conditional_t<kElementsAreMaybeObject, MaybeObjectSlot, ObjectSlot>;
 
  public:
-  using Shape = ShapeT;
+  using ShapeT = Shape;
 
   inline int capacity() const;
   inline int capacity(AcquireLoadTag) const;
@@ -183,6 +183,7 @@ class FixedArray : public TaggedArrayBase<FixedArray, TaggedArrayShape> {
   OBJECT_CONSTRUCTORS(FixedArray, Super);
 
  public:
+  using HotfixShape = TaggedArrayShape;
   template <class IsolateT>
   static inline Handle<FixedArray> New(
       IsolateT* isolate, int capacity,
@@ -228,7 +229,7 @@ class FixedArray : public TaggedArrayBase<FixedArray, TaggedArrayShape> {
 
   class BodyDescriptor;
 
-  static constexpr int kLengthOffset = Shape::kCapacityOffset;
+  static constexpr int kLengthOffset = ShapeT::kCapacityOffset;
   static constexpr int kMaxLength = FixedArray::kMaxCapacity;
   static constexpr int kMaxRegularLength = FixedArray::kMaxRegularCapacity;
 
@@ -333,6 +334,7 @@ class PrimitiveArrayBase : public Super {
 
  public:
   using Shape = ShapeT;
+  using HotfixShape = ShapeT;
   static constexpr bool kElementsAreMaybeObject = false;
 
   inline int length() const;
@@ -467,6 +469,8 @@ class WeakFixedArray
   OBJECT_CONSTRUCTORS(WeakFixedArray, Super);
 
  public:
+  using Shape = WeakFixedArrayShape;
+  using HotfixShape = WeakFixedArrayShape;
   template <class IsolateT>
   static inline Handle<WeakFixedArray> New(
       IsolateT* isolate, int capacity,
@@ -478,7 +482,7 @@ class WeakFixedArray
 
   class BodyDescriptor;
 
-  static constexpr int kLengthOffset = Shape::kCapacityOffset;
+  static constexpr int kLengthOffset = ShapeT::kCapacityOffset;
 };
 
 // WeakArrayList is like a WeakFixedArray with static convenience methods for
@@ -614,6 +618,7 @@ class ArrayList : public TaggedArrayBase<ArrayList, ArrayListShape> {
 
  public:
   using Shape = ArrayListShape;
+  using HotfixShape = ArrayListShape;
 
   template <class IsolateT>
   static inline Handle<ArrayList> New(
@@ -685,6 +690,7 @@ class ByteArray : public PrimitiveArrayBase<ByteArray, ByteArrayShape> {
 
  public:
   using Shape = ByteArrayShape;
+  using HotfixShape = ByteArrayShape;
 
   template <class IsolateT>
   static inline Handle<ByteArray> New(

--- a/deps/v8/src/objects/hash-table-inl.h
+++ b/deps/v8/src/objects/hash-table-inl.h
@@ -170,7 +170,7 @@ template <typename Derived, typename Shape>
 template <typename IsolateT>
 InternalIndex HashTable<Derived, Shape>::FindEntry(IsolateT* isolate, Key key) {
   ReadOnlyRoots roots(isolate);
-  return FindEntry(isolate, roots, key, TodoShape::Hash(roots, key));
+  return FindEntry(isolate, roots, key, Shape::Hash(roots, key));
 }
 
 // Find entry for key otherwise return kNotFound.
@@ -183,7 +183,7 @@ InternalIndex HashTable<Derived, Shape>::FindEntry(PtrComprCageBase cage_base,
   uint32_t count = 1;
   Tagged<Object> undefined = roots.undefined_value();
   Tagged<Object> the_hole = roots.the_hole_value();
-  DCHECK_EQ(TodoShape::Hash(roots, key), static_cast<uint32_t>(hash));
+  DCHECK_EQ(Shape::Hash(roots, key), static_cast<uint32_t>(hash));
   // EnsureCapacity will guarantee the hash table is never full.
   for (InternalIndex entry = FirstProbe(hash, capacity);;
        entry = NextProbe(entry, count++, capacity)) {
@@ -191,8 +191,8 @@ InternalIndex HashTable<Derived, Shape>::FindEntry(PtrComprCageBase cage_base,
     // Empty entry. Uses raw unchecked accessors because it is called by the
     // string table during bootstrapping.
     if (element == undefined) return InternalIndex::NotFound();
-    if (TodoShape::kMatchNeedsHoleCheck && element == the_hole) continue;
-    if (TodoShape::IsMatch(key, element)) return entry;
+    if (Shape::kMatchNeedsHoleCheck && element == the_hole) continue;
+    if (Shape::IsMatch(key, element)) return entry;
   }
 }
 
@@ -216,7 +216,7 @@ bool HashTable<Derived, Shape>::ToKey(ReadOnlyRoots roots, InternalIndex entry,
                                       Tagged<Object>* out_k) {
   Tagged<Object> k = KeyAt(entry);
   if (!IsKey(roots, k)) return false;
-  *out_k = TodoShape::Unwrap(k);
+  *out_k = Shape::Unwrap(k);
   return true;
 }
 
@@ -226,7 +226,7 @@ bool HashTable<Derived, Shape>::ToKey(PtrComprCageBase cage_base,
                                       Tagged<Object>* out_k) {
   Tagged<Object> k = KeyAt(cage_base, entry);
   if (!IsKey(GetReadOnlyRoots(cage_base), k)) return false;
-  *out_k = TodoShape::Unwrap(k);
+  *out_k = Shape::Unwrap(k);
   return true;
 }
 

--- a/deps/v8/src/objects/hash-table.h
+++ b/deps/v8/src/objects/hash-table.h
@@ -126,15 +126,15 @@ class V8_EXPORT_PRIVATE HashTableBase : public NON_EXPORTED_BASE(FixedArray) {
   OBJECT_CONSTRUCTORS(HashTableBase, FixedArray);
 };
 
-template <typename Derived, typename ShapeT>
+template <typename Derived, typename Shape>
 class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) HashTable
     : public HashTableBase {
  public:
   // TODO(jgruber): Derive from TaggedArrayBase instead of FixedArray, and
   // merge with TaggedArraryBase's Shape class. Once the naming conflict is
   // resolved rename all TodoShape occurrences back to Shape.
-  using TodoShape = ShapeT;
-  using Key = typename TodoShape::Key;
+  using ShapeT = Shape;
+  using Key = typename Shape::Key;
 
   // Returns a new HashTable object.
   template <typename IsolateT>
@@ -177,9 +177,8 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) HashTable
   inline void SetKeyAt(InternalIndex entry, Tagged<Object> value,
                        WriteBarrierMode mode = UPDATE_WRITE_BARRIER);
 
-  static const int kElementsStartIndex =
-      kPrefixStartIndex + TodoShape::kPrefixSize;
-  static const int kEntrySize = TodoShape::kEntrySize;
+  static const int kElementsStartIndex = kPrefixStartIndex + Shape::kPrefixSize;
+  static const int kEntrySize = Shape::kEntrySize;
   static_assert(kEntrySize > 0);
   static const int kEntryKeyIndex = 0;
   static const int kElementsStartOffset =

--- a/deps/v8/src/objects/template-objects.cc
+++ b/deps/v8/src/objects/template-objects.cc
@@ -54,7 +54,7 @@ Handle<JSArray> TemplateObjectDescription::GetTemplateObject(
   // Check the template weakmap to see if the template object already exists.
   Handle<Script> script(Script::cast(shared_info->script(isolate)), isolate);
   int32_t hash =
-      EphemeronHashTable::TodoShape::Hash(ReadOnlyRoots(isolate), script);
+      EphemeronHashTable::ShapeT::Hash(ReadOnlyRoots(isolate), script);
   MaybeHandle<ArrayList> maybe_cached_templates;
 
   if (!IsUndefined(native_context->template_weakmap(), isolate)) {


### PR DESCRIPTION
This PR patches V8 v12.2 for Windows, by fixing multiple compilation errors caused by V8 being a Clang-oriented project. There are various types of errors fixed by this going from changing `using` directives and renaming to overcoming the differences in which Clang and MSVC see templates and metaprogramming.

The changes introduced here are strictly meant as a patch only, so they shouldn't be pushed upstream. Furthermore, the changes will most likely not apply to the next V8 eg. v12.3 directly as a patch (the original V8 update started on v12,1 and after I fixed it and rebased to v12.2 I couldn't apply patches via `git apply ...`, but had to do it manually with some additional changes). With that in mind, it would be good to finish the V8 update with the current version, so no additional work is needed on this.

To make sure all was working well, I ran the Windows CI. The compilation and testing [passed](https://ci.nodejs.org/job/node-test-commit-windows-fanned/60443/). I didn't test on other platforms since some of them already have issues based on the CI in the original PR.

@targos, I'm open to any questions, suggestions, etc. I left the original 3 commits just for context (the first one was done as part of my work on https://github.com/nodejs/node-v8/issues/271), but when making a patch out of this I see no reason not to squash it.