### PR TITLE
V8 v12.3 patch

### DIFF
--- a/deps/v8/src/builtins/builtins-collections-gen.cc
+++ b/deps/v8/src/builtins/builtins-collections-gen.cc
@@ -2782,10 +2782,9 @@ TNode<Word32T> WeakCollectionsBuiltinsAssembler::ShouldShrink(
 
 TNode<IntPtrT> WeakCollectionsBuiltinsAssembler::ValueIndexFromKeyIndex(
     TNode<IntPtrT> key_index) {
-  return IntPtrAdd(
-      key_index,
-      IntPtrConstant(EphemeronHashTable::TodoShape::kEntryValueIndex -
-                     EphemeronHashTable::kEntryKeyIndex));
+  return IntPtrAdd(key_index,
+                   IntPtrConstant(EphemeronHashTable::ShapeT::kEntryValueIndex -
+                                  EphemeronHashTable::kEntryKeyIndex));
 }
 
 TF_BUILTIN(WeakMapConstructor, WeakCollectionsBuiltinsAssembler) {

--- a/deps/v8/src/codegen/code-stub-assembler.cc
+++ b/deps/v8/src/codegen/code-stub-assembler.cc
@@ -9505,7 +9505,7 @@ void CodeStubAssembler::NameDictionaryLookup(
         CAST(UnsafeLoadFixedArrayElement(dictionary, index));
     GotoIf(TaggedEqual(current, undefined), if_not_found_with_insertion_index);
     if (mode == kFindExisting) {
-      if (Dictionary::TodoShape::kMatchNeedsHoleCheck) {
+      if (Dictionary::ShapeT::kMatchNeedsHoleCheck) {
         GotoIf(TaggedEqual(current, TheHoleConstant()), &next_probe);
       }
       current = LoadName<Dictionary>(current);

--- a/deps/v8/src/codegen/code-stub-assembler.h
+++ b/deps/v8/src/codegen/code-stub-assembler.h
@@ -1547,7 +1547,7 @@ class V8_EXPORT_PRIVATE CodeStubAssembler
   TNode<Smi> LoadFixedArrayBaseLength(TNode<FixedArrayBase> array);
   template <typename Array>
   TNode<Smi> LoadArrayCapacity(TNode<Array> array) {
-    return LoadObjectField<Smi>(array, Array::Shape::kCapacityOffset);
+    return LoadObjectField<Smi>(array, Array::ShapeT::kCapacityOffset);
   }
   // Load the length of a fixed array base instance.
   TNode<IntPtrT> LoadAndUntagFixedArrayBaseLength(TNode<FixedArrayBase> array);

--- a/deps/v8/src/compiler/turboshaft/simplified-lowering-reducer.h
+++ b/deps/v8/src/compiler/turboshaft/simplified-lowering-reducer.h
@@ -32,10 +32,10 @@ class SimplifiedLoweringReducer : public Next {
       OpIndex ig_index, const SpeculativeNumberBinopOp& op) {
     DCHECK_EQ(op.kind, SpeculativeNumberBinopOp::Kind::kSafeIntegerAdd);
 
-    OpIndex frame_state = Map(op.frame_state());
-    V<Word32> left = ProcessInput(Map(op.left()), Rep::Word32(),
+    OpIndex frame_state = MapImpl(op.frame_state());
+    V<Word32> left = ProcessInput(MapImpl(op.left()), Rep::Word32(),
                                   CheckKind::kSigned32, frame_state);
-    V<Word32> right = ProcessInput(Map(op.right()), Rep::Word32(),
+    V<Word32> right = ProcessInput(MapImpl(op.right()), Rep::Word32(),
                                    CheckKind::kSigned32, frame_state);
 
     V<Word32> result = __ OverflowCheckedBinop(
@@ -43,7 +43,7 @@ class SimplifiedLoweringReducer : public Next {
         WordRepresentation::Word32());
 
     V<Word32> overflow = __ Projection(result, 1, Rep::Word32());
-    __ DeoptimizeIf(overflow, Map(op.frame_state()),
+    __ DeoptimizeIf(overflow, MapImpl(op.frame_state()),
                     DeoptimizeReason::kOverflow, FeedbackSource{});
     return __ Projection(result, 0, Rep::Word32());
   }
@@ -52,10 +52,10 @@ class SimplifiedLoweringReducer : public Next {
     base::SmallVector<OpIndex, 8> return_values;
     for (OpIndex input : ret.return_values()) {
       return_values.push_back(
-          ProcessInput(Map(input), Rep::Tagged(), CheckKind::kNone, {}));
+          ProcessInput(MapImpl(input), Rep::Tagged(), CheckKind::kNone, {}));
     }
 
-    __ Return(Map(ret.pop_count()), base::VectorOf(return_values));
+    __ Return(MapImpl(ret.pop_count()), base::VectorOf(return_values));
     return OpIndex::Invalid();
   }
 
@@ -94,7 +94,7 @@ class SimplifiedLoweringReducer : public Next {
     }
   }
 
-  inline OpIndex Map(OpIndex ig_index) { return __ MapToNewGraph(ig_index); }
+  inline OpIndex MapImpl(OpIndex ig_index) { return __ MapToNewGraph(ig_index); }
 };
 
 #include "src/compiler/turboshaft/undef-assembler-macros.inc"

--- a/deps/v8/src/compiler/turboshaft/variable-reducer.h
+++ b/deps/v8/src/compiler/turboshaft/variable-reducer.h
@@ -55,9 +55,11 @@ namespace v8::internal::compiler::turboshaft {
 // with constant inputs introduced by `VariableReducer` need to be eliminated.
 template <class AfterNext>
 class VariableReducer : public RequiredOptimizationReducer<AfterNext> {
+protected:
   using Next = RequiredOptimizationReducer<AfterNext>;
   using Snapshot = SnapshotTable<OpIndex, VariableData>::Snapshot;
 
+private:
   struct GetActiveLoopVariablesIndex {
     IntrusiveSetIndex& operator()(Variable var) const {
       return var.data().active_loop_variables_index;

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -3570,7 +3570,7 @@ void Heap::RightTrimArray(Tagged<Array> object, int new_capacity,
   }
 
   const int bytes_to_trim =
-      (old_capacity - new_capacity) * Array::Shape::kElementSize;
+      (old_capacity - new_capacity) * Array::HotfixShape::kElementSize;
 
   // Calculate location of new array end.
   const int old_size = Array::SizeFor(old_capacity);

--- a/deps/v8/src/objects/dictionary.h
+++ b/deps/v8/src/objects/dictionary.h
@@ -32,8 +32,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) Dictionary
   using DerivedHashTable = HashTable<Derived, Shape>;
 
  public:
-  using TodoShape = Shape;
-  using Key = typename TodoShape::Key;
+  using Key = typename Shape::Key;
   inline Tagged<Object> ValueAt(InternalIndex entry);
   inline Tagged<Object> ValueAt(PtrComprCageBase cage_base,
                                 InternalIndex entry);
@@ -126,7 +125,7 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) Dictionary
                              Key key, Handle<Object> value,
                              PropertyDetails details);
 
-  OBJECT_CONSTRUCTORS(Dictionary, HashTable<Derived, TodoShape>);
+  OBJECT_CONSTRUCTORS(Dictionary, HashTable<Derived, Shape>);
 };
 
 #define EXTERN_DECLARE_DICTIONARY(DERIVED, SHAPE)                  \

--- a/deps/v8/src/objects/fixed-array.h
+++ b/deps/v8/src/objects/fixed-array.h
@@ -24,18 +24,18 @@ namespace internal {
 #include "torque-generated/src/objects/fixed-array-tq.inc"
 
 // Derived: must have a Smi slot at kCapacityOffset.
-template <class Derived, class ShapeT, class Super = HeapObject>
+template <class Derived, class Shape, class Super = HeapObject>
 class TaggedArrayBase : public Super {
   static_assert(std::is_base_of<HeapObject, Super>::value);
   OBJECT_CONSTRUCTORS(TaggedArrayBase, Super);
 
-  using ElementT = typename ShapeT::ElementT;
-  static_assert(ShapeT::kElementSize == kTaggedSize);
+  using ElementT = typename Shape::ElementT;
+  static_assert(Shape::kElementSize == kTaggedSize);
   static_assert(is_subtype_v<ElementT, Object> ||
                 is_subtype_v<ElementT, MaybeObject>);
 
   using ElementFieldT =
-      TaggedField<ElementT, 0, typename ShapeT::CompressionScheme>;
+      TaggedField<ElementT, 0, typename Shape::CompressionScheme>;
 
   static constexpr bool kSupportsSmiElements =
       std::is_convertible_v<Smi, ElementT>;
@@ -56,7 +56,7 @@ class TaggedArrayBase : public Super {
       std::conditional_t<kElementsAreMaybeObject, MaybeObjectSlot, ObjectSlot>;
 
  public:
-  using Shape = ShapeT;
+  using ShapeT = Shape;
 
   inline int capacity() const;
   inline int capacity(AcquireLoadTag) const;
@@ -187,6 +187,7 @@ class FixedArray : public TaggedArrayBase<FixedArray, TaggedArrayShape> {
   OBJECT_CONSTRUCTORS(FixedArray, Super);
 
  public:
+  using HotfixShape = TaggedArrayShape;
   template <class IsolateT>
   static inline Handle<FixedArray> New(
       IsolateT* isolate, int capacity,
@@ -232,7 +233,7 @@ class FixedArray : public TaggedArrayBase<FixedArray, TaggedArrayShape> {
 
   class BodyDescriptor;
 
-  static constexpr int kLengthOffset = Shape::kCapacityOffset;
+  static constexpr int kLengthOffset = ShapeT::kCapacityOffset;
   static constexpr int kMaxLength = FixedArray::kMaxCapacity;
   static constexpr int kMaxRegularLength = FixedArray::kMaxRegularCapacity;
 
@@ -283,7 +284,7 @@ class TrustedFixedArray
   class BodyDescriptor;
 
   static constexpr int kLengthOffset =
-      TrustedFixedArray::Shape::kCapacityOffset;
+      TrustedFixedArray::ShapeT::kCapacityOffset;
   static constexpr int kMaxLength = TrustedFixedArray::kMaxCapacity;
   static constexpr int kMaxRegularLength =
       TrustedFixedArray::kMaxRegularCapacity;
@@ -331,7 +332,7 @@ class ProtectedFixedArray
   class BodyDescriptor;
 
   static constexpr int kLengthOffset =
-      ProtectedFixedArray::Shape::kCapacityOffset;
+      ProtectedFixedArray::ShapeT::kCapacityOffset;
   static constexpr int kMaxLength = ProtectedFixedArray::kMaxCapacity;
   static constexpr int kMaxRegularLength =
       ProtectedFixedArray::kMaxRegularCapacity;
@@ -388,6 +389,7 @@ class PrimitiveArrayBase : public Super {
 
  public:
   using Shape = ShapeT;
+  using HotfixShape = ShapeT;
   static constexpr bool kElementsAreMaybeObject = false;
 
   inline int length() const;
@@ -523,6 +525,8 @@ class WeakFixedArray
   OBJECT_CONSTRUCTORS(WeakFixedArray, Super);
 
  public:
+  using Shape = WeakFixedArrayShape;
+  using HotfixShape = WeakFixedArrayShape;
   template <class IsolateT>
   static inline Handle<WeakFixedArray> New(
       IsolateT* isolate, int capacity,
@@ -534,7 +538,7 @@ class WeakFixedArray
 
   class BodyDescriptor;
 
-  static constexpr int kLengthOffset = Shape::kCapacityOffset;
+  static constexpr int kLengthOffset = ShapeT::kCapacityOffset;
 };
 
 // WeakArrayList is like a WeakFixedArray with static convenience methods for
@@ -671,6 +675,7 @@ class ArrayList : public TaggedArrayBase<ArrayList, ArrayListShape> {
 
  public:
   using Shape = ArrayListShape;
+  using HotfixShape = ArrayListShape;
 
   template <class IsolateT>
   static inline Handle<ArrayList> New(
@@ -742,6 +747,7 @@ class ByteArray : public PrimitiveArrayBase<ByteArray, ByteArrayShape> {
 
  public:
   using Shape = ByteArrayShape;
+  using HotfixShape = ByteArrayShape;
 
   template <class IsolateT>
   static inline Handle<ByteArray> New(

--- a/deps/v8/src/objects/hash-table-inl.h
+++ b/deps/v8/src/objects/hash-table-inl.h
@@ -170,7 +170,7 @@ template <typename Derived, typename Shape>
 template <typename IsolateT>
 InternalIndex HashTable<Derived, Shape>::FindEntry(IsolateT* isolate, Key key) {
   ReadOnlyRoots roots(isolate);
-  return FindEntry(isolate, roots, key, TodoShape::Hash(roots, key));
+  return FindEntry(isolate, roots, key, Shape::Hash(roots, key));
 }
 
 // Find entry for key otherwise return kNotFound.
@@ -183,7 +183,7 @@ InternalIndex HashTable<Derived, Shape>::FindEntry(PtrComprCageBase cage_base,
   uint32_t count = 1;
   Tagged<Object> undefined = roots.undefined_value();
   Tagged<Object> the_hole = roots.the_hole_value();
-  DCHECK_EQ(TodoShape::Hash(roots, key), static_cast<uint32_t>(hash));
+  DCHECK_EQ(Shape::Hash(roots, key), static_cast<uint32_t>(hash));
   // EnsureCapacity will guarantee the hash table is never full.
   for (InternalIndex entry = FirstProbe(hash, capacity);;
        entry = NextProbe(entry, count++, capacity)) {
@@ -191,8 +191,8 @@ InternalIndex HashTable<Derived, Shape>::FindEntry(PtrComprCageBase cage_base,
     // Empty entry. Uses raw unchecked accessors because it is called by the
     // string table during bootstrapping.
     if (element == undefined) return InternalIndex::NotFound();
-    if (TodoShape::kMatchNeedsHoleCheck && element == the_hole) continue;
-    if (TodoShape::IsMatch(key, element)) return entry;
+    if (Shape::kMatchNeedsHoleCheck && element == the_hole) continue;
+    if (Shape::IsMatch(key, element)) return entry;
   }
 }
 
@@ -216,7 +216,7 @@ bool HashTable<Derived, Shape>::ToKey(ReadOnlyRoots roots, InternalIndex entry,
                                       Tagged<Object>* out_k) {
   Tagged<Object> k = KeyAt(entry);
   if (!IsKey(roots, k)) return false;
-  *out_k = TodoShape::Unwrap(k);
+  *out_k = Shape::Unwrap(k);
   return true;
 }
 
@@ -226,7 +226,7 @@ bool HashTable<Derived, Shape>::ToKey(PtrComprCageBase cage_base,
                                       Tagged<Object>* out_k) {
   Tagged<Object> k = KeyAt(cage_base, entry);
   if (!IsKey(GetReadOnlyRoots(cage_base), k)) return false;
-  *out_k = TodoShape::Unwrap(k);
+  *out_k = Shape::Unwrap(k);
   return true;
 }
 

--- a/deps/v8/src/objects/hash-table.h
+++ b/deps/v8/src/objects/hash-table.h
@@ -126,15 +126,15 @@ class V8_EXPORT_PRIVATE HashTableBase : public NON_EXPORTED_BASE(FixedArray) {
   OBJECT_CONSTRUCTORS(HashTableBase, FixedArray);
 };
 
-template <typename Derived, typename ShapeT>
+template <typename Derived, typename Shape>
 class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) HashTable
     : public HashTableBase {
  public:
   // TODO(jgruber): Derive from TaggedArrayBase instead of FixedArray, and
   // merge with TaggedArraryBase's Shape class. Once the naming conflict is
   // resolved rename all TodoShape occurrences back to Shape.
-  using TodoShape = ShapeT;
-  using Key = typename TodoShape::Key;
+  using ShapeT = Shape;
+  using Key = typename Shape::Key;
 
   // Returns a new HashTable object.
   template <typename IsolateT>
@@ -177,9 +177,8 @@ class EXPORT_TEMPLATE_DECLARE(V8_EXPORT_PRIVATE) HashTable
   inline void SetKeyAt(InternalIndex entry, Tagged<Object> value,
                        WriteBarrierMode mode = UPDATE_WRITE_BARRIER);
 
-  static const int kElementsStartIndex =
-      kPrefixStartIndex + TodoShape::kPrefixSize;
-  static const int kEntrySize = TodoShape::kEntrySize;
+  static const int kElementsStartIndex = kPrefixStartIndex + Shape::kPrefixSize;
+  static const int kEntrySize = Shape::kEntrySize;
   static_assert(kEntrySize > 0);
   static const int kEntryKeyIndex = 0;
   static const int kElementsStartOffset =

--- a/deps/v8/src/objects/objects.cc
+++ b/deps/v8/src/objects/objects.cc
@@ -5137,11 +5137,11 @@ void HashTable<Derived, Shape>::Rehash(PtrComprCageBase cage_base,
     uint32_t from_index = EntryToIndex(i);
     Tagged<Object> k = this->get(from_index);
     if (!IsKey(roots, k)) continue;
-    uint32_t hash = TodoShape::HashForObject(roots, k);
+    uint32_t hash = Shape::HashForObject(roots, k);
     uint32_t insertion_index =
         EntryToIndex(new_table->FindInsertionEntry(cage_base, roots, hash));
     new_table->set_key(insertion_index, get(from_index), mode);
-    for (int j = 1; j < TodoShape::kEntrySize; j++) {
+    for (int j = 1; j < Shape::kEntrySize; j++) {
       new_table->set(insertion_index + j, get(from_index + j), mode);
     }
   }
@@ -5154,7 +5154,7 @@ InternalIndex HashTable<Derived, Shape>::EntryForProbe(ReadOnlyRoots roots,
                                                        Tagged<Object> k,
                                                        int probe,
                                                        InternalIndex expected) {
-  uint32_t hash = TodoShape::HashForObject(roots, k);
+  uint32_t hash = Shape::HashForObject(roots, k);
   uint32_t capacity = this->Capacity();
   InternalIndex entry = FirstProbe(hash, capacity);
   for (int i = 1; i < probe; i++) {
@@ -5169,17 +5169,17 @@ void HashTable<Derived, Shape>::Swap(InternalIndex entry1, InternalIndex entry2,
                                      WriteBarrierMode mode) {
   int index1 = EntryToIndex(entry1);
   int index2 = EntryToIndex(entry2);
-  Tagged<Object> temp[TodoShape::kEntrySize];
+  Tagged<Object> temp[Shape::kEntrySize];
   Derived* self = static_cast<Derived*>(this);
-  for (int j = 0; j < TodoShape::kEntrySize; j++) {
+  for (int j = 0; j < Shape::kEntrySize; j++) {
     temp[j] = get(index1 + j);
   }
   self->set_key(index1, get(index2), mode);
-  for (int j = 1; j < TodoShape::kEntrySize; j++) {
+  for (int j = 1; j < Shape::kEntrySize; j++) {
     set(index1 + j, get(index2 + j), mode);
   }
   self->set_key(index2, temp[0], mode);
-  for (int j = 1; j < TodoShape::kEntrySize; j++) {
+  for (int j = 1; j < Shape::kEntrySize; j++) {
     set(index2 + j, temp[j], mode);
   }
 }
@@ -5341,7 +5341,7 @@ GlobalDictionary::TryFindPropertyCellForConcurrentLookupIterator(
   DisallowGarbageCollection no_gc;
   PtrComprCageBase cage_base{isolate};
   ReadOnlyRoots roots(isolate);
-  const int32_t hash = TodoShape::Hash(roots, name);
+  const int32_t hash = ShapeT::Hash(roots, name);
   const uint32_t capacity = Capacity();
   uint32_t count = 1;
   Tagged<Object> undefined = roots.undefined_value();
@@ -5352,8 +5352,8 @@ GlobalDictionary::TryFindPropertyCellForConcurrentLookupIterator(
     Tagged<Object> element = KeyAt(cage_base, entry, kRelaxedLoad);
     if (isolate->heap()->IsPendingAllocation(element)) return {};
     if (element == undefined) return {};
-    if (TodoShape::kMatchNeedsHoleCheck && element == the_hole) continue;
-    if (!TodoShape::IsMatch(name, element)) continue;
+    if (ShapeT::kMatchNeedsHoleCheck && element == the_hole) continue;
+    if (!ShapeT::IsMatch(name, element)) continue;
     CHECK(IsPropertyCell(element, cage_base));
     return PropertyCell::cast(element);
   }
@@ -5367,7 +5367,7 @@ Handle<StringSet> StringSet::Add(Isolate* isolate, Handle<StringSet> stringset,
                                  Handle<String> name) {
   if (!stringset->Has(isolate, name)) {
     stringset = EnsureCapacity(isolate, stringset);
-    uint32_t hash = TodoShape::Hash(ReadOnlyRoots(isolate), *name);
+    uint32_t hash = ShapeT::Hash(ReadOnlyRoots(isolate), *name);
     InternalIndex entry = stringset->FindInsertionEntry(isolate, hash);
     stringset->set(EntryToIndex(entry), *name);
     stringset->ElementAdded();
@@ -5386,7 +5386,7 @@ Handle<RegisteredSymbolTable> RegisteredSymbolTable::Add(
   SLOW_DCHECK(table->FindEntry(isolate, key).is_not_found());
 
   table = EnsureCapacity(isolate, table);
-  uint32_t hash = TodoShape::Hash(ReadOnlyRoots(isolate), key);
+  uint32_t hash = ShapeT::Hash(ReadOnlyRoots(isolate), key);
   InternalIndex entry = table->FindInsertionEntry(isolate, hash);
   table->set(EntryToIndex(entry), *key);
   table->set(EntryToValueIndex(entry), *symbol);
@@ -5455,7 +5455,7 @@ int BaseNameDictionary<Derived, Shape>::NextEnumerationIndex(
 template <typename Derived, typename Shape>
 Handle<Derived> Dictionary<Derived, Shape>::DeleteEntry(
     Isolate* isolate, Handle<Derived> dictionary, InternalIndex entry) {
-  DCHECK(TodoShape::kEntrySize != 3 ||
+  DCHECK(Shape::kEntrySize != 3 ||
          dictionary->DetailsAt(entry).IsConfigurable());
   dictionary->ClearEntry(entry);
   dictionary->ElementRemoved();
@@ -5476,7 +5476,7 @@ Handle<Derived> Dictionary<Derived, Shape>::AtPut(Isolate* isolate,
 
   // We don't need to copy over the enumeration index.
   dictionary->ValueAtPut(entry, *value);
-  if (TodoShape::kEntrySize == 3) dictionary->DetailsAtPut(entry, details);
+  if (Shape::kEntrySize == 3) dictionary->DetailsAtPut(entry, details);
   return dictionary;
 }
 
@@ -5493,7 +5493,7 @@ void Dictionary<Derived, Shape>::UncheckedAtPut(Isolate* isolate,
   } else {
     // We don't need to copy over the enumeration index.
     dictionary->ValueAtPut(entry, *value);
-    if (TodoShape::kEntrySize == 3) dictionary->DetailsAtPut(entry, details);
+    if (Shape::kEntrySize == 3) dictionary->DetailsAtPut(entry, details);
   }
 }
 
@@ -5534,19 +5534,19 @@ Handle<Derived> Dictionary<Derived, Shape>::Add(IsolateT* isolate,
                                                 PropertyDetails details,
                                                 InternalIndex* entry_out) {
   ReadOnlyRoots roots(isolate);
-  uint32_t hash = TodoShape::Hash(roots, key);
+  uint32_t hash = Shape::Hash(roots, key);
   // Validate that the key is absent.
   SLOW_DCHECK(dictionary->FindEntry(isolate, key).is_not_found());
   // Check whether the dictionary should be extended.
   dictionary = Derived::EnsureCapacity(isolate, dictionary);
 
   // Compute the key object.
-  Handle<Object> k = TodoShape::template AsHandle<key_allocation>(isolate, key);
+  Handle<Object> k = Shape::template AsHandle<key_allocation>(isolate, key);
 
   InternalIndex entry = dictionary->FindInsertionEntry(isolate, roots, hash);
   dictionary->SetEntry(entry, *k, *value, details);
   DCHECK(IsNumber(dictionary->KeyAt(isolate, entry)) ||
-         IsUniqueName(TodoShape::Unwrap(dictionary->KeyAt(isolate, entry))));
+         IsUniqueName(Shape::Unwrap(dictionary->KeyAt(isolate, entry))));
   dictionary->ElementAdded();
   if (entry_out) *entry_out = entry;
   return dictionary;
@@ -5559,18 +5559,18 @@ void Dictionary<Derived, Shape>::UncheckedAdd(IsolateT* isolate,
                                               Key key, Handle<Object> value,
                                               PropertyDetails details) {
   ReadOnlyRoots roots(isolate);
-  uint32_t hash = TodoShape::Hash(roots, key);
+  uint32_t hash = Shape::Hash(roots, key);
   // Validate that the key is absent and we capacity is sufficient.
   SLOW_DCHECK(dictionary->FindEntry(isolate, key).is_not_found());
   DCHECK(dictionary->HasSufficientCapacityToAdd(1));
 
   // Compute the key object.
-  Handle<Object> k = TodoShape::template AsHandle<key_allocation>(isolate, key);
+  Handle<Object> k = Shape::template AsHandle<key_allocation>(isolate, key);
 
   InternalIndex entry = dictionary->FindInsertionEntry(isolate, roots, hash);
   dictionary->SetEntry(entry, *k, *value, details);
   DCHECK(IsNumber(dictionary->KeyAt(isolate, entry)) ||
-         IsUniqueName(TodoShape::Unwrap(dictionary->KeyAt(isolate, entry))));
+         IsUniqueName(Shape::Unwrap(dictionary->KeyAt(isolate, entry))));
 }
 
 template <typename Derived, typename Shape>

--- a/deps/v8/src/objects/tagged-field.h
+++ b/deps/v8/src/objects/tagged-field.h
@@ -100,12 +100,10 @@ static_assert(sizeof(UnalignedDoubleMember) == sizeof(double));
 #define FLEXIBLE_ARRAY_MEMBER(Type, name)                     \
   using FlexibleDataReturnType = Type[0];                     \
   FlexibleDataReturnType& name() {                            \
-    static_assert(alignof(Type) <= alignof(decltype(*this))); \
     using ReturnType = Type[0];                               \
     return reinterpret_cast<ReturnType&>(*(this + 1));        \
   }                                                           \
   const FlexibleDataReturnType& name() const {                \
-    static_assert(alignof(Type) <= alignof(decltype(*this))); \
     using ReturnType = Type[0];                               \
     return reinterpret_cast<const ReturnType&>(*(this + 1));  \
   }                                                           \

--- a/deps/v8/src/objects/template-objects.cc
+++ b/deps/v8/src/objects/template-objects.cc
@@ -54,7 +54,7 @@ Handle<JSArray> TemplateObjectDescription::GetTemplateObject(
   // Check the template weakmap to see if the template object already exists.
   Handle<Script> script(Script::cast(shared_info->script(isolate)), isolate);
   int32_t hash =
-      EphemeronHashTable::TodoShape::Hash(ReadOnlyRoots(isolate), script);
+      EphemeronHashTable::ShapeT::Hash(ReadOnlyRoots(isolate), script);
   MaybeHandle<ArrayList> maybe_cached_templates;
 
   if (!IsUndefined(native_context->template_weakmap(), isolate)) {

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -930,6 +930,13 @@
           ],
         }],
       ],
+      'msvs_settings': {
+        'VCCLCompilerTool': {
+          'AdditionalOptions': [
+            '/bigobj'
+          ],
+        },
+      },
     },  # v8_turboshaft
     {
       'target_name': 'v8_compiler_for_mksnapshot',


### PR DESCRIPTION
This patches V8 v12.3 for Windows, by fixing multiple compilation errors caused by V8 being a Clang-oriented project. There are various types of errors fixed by this going from changing `using` directives and renaming to overcoming the differences in which Clang and MSVC see templates and metaprogramming.

The changes introduced here are strictly meant as a patch only, so they shouldn't be pushed upstream.

Refs: https://github.com/targos/node/pull/13
Refs: https://github.com/targos/node/pull/14